### PR TITLE
Fix: navbar responsive issue on small screens

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -113,6 +113,15 @@
   box-sizing: border-box;
 }
 
+/* Fix navbar overflow on small screens - START */
+html, body {
+  width: 100%;
+  overflow-x: hidden;
+  margin: 0;
+  padding: 0;
+}
+/* Fix navbar overflow on small screens - END */
+
 li { list-style: none; }
 
 a,


### PR DESCRIPTION
The navbar menu was extending beyond the screen width on mobile view. Also the contents in mobile view taking more spaces in right side then left. 
- Added CSS rules to make navbar 100% width on small screens
